### PR TITLE
Global certificate support for services

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -10,7 +10,7 @@ import (
 )
 
 type CLI struct {
-	newServer    func(string, string, int, int) types.Startable
+	newServer    func(string, string, string, string, int, int) types.Startable
 	newCollector func(int, string) types.Startable
 }
 
@@ -44,6 +44,16 @@ func (c *CLI) Start(args []string) {
 					Value: "127.0.0.1",
 					Usage: "Bind to `address`",
 				},
+        cli.StringFlag{
+          Name:  "cert, c",
+          Value: "",
+          Usage: "Global wildcard certificate for services.",
+        },
+        cli.StringFlag{
+          Name:  "key, k",
+          Value: "",
+          Usage: "Global key for wildcard cert.",
+        },
 				cli.IntFlag{
 					Name:  "max-body-size",
 					Value: 4,
@@ -64,7 +74,7 @@ func (c *CLI) Start(args []string) {
         // Increase this buffer if your clients send multi-KB RequestURIs
         // and/or multi-KB headers (for example, BIG cookies, things like kerberos
         // and others which use larger sizes than 4KB)
-				server := c.newServer(ctx.String("bind"), ctx.GlobalString("redis"), ctx.Int("max-body-size")*1024*1024, ctx.Int("read-buffer-size")*1024)
+				server := c.newServer(ctx.String("bind"), ctx.GlobalString("redis"), ctx.String("cert"), ctx.String("key"), ctx.Int("max-body-size")*1024*1024, ctx.Int("read-buffer-size")*1024)
 				server.Start()
 				return nil
 			},

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -17,6 +17,8 @@ type TestServer struct {
 	maxBodySize int
   readBufferSize int
 	started     bool
+  cert        string
+  key         string
 }
 
 func (s *TestServer) Start() {
@@ -33,9 +35,11 @@ func (c *TestCollector) Start() {
 	c.started = true
 }
 
-func newTestServer(bind, redis string, maxBodySize int, readBufferSize int) types.Startable {
+func newTestServer(bind, redis, cert, key string, maxBodySize int, readBufferSize int) types.Startable {
 	fakeServer.bindAddress = bind
 	fakeServer.redis = redis
+  fakeServer.cert = cert
+  fakeServer.key = key
 	fakeServer.maxBodySize = maxBodySize
   fakeServer.readBufferSize = readBufferSize
 	fakeServer.started = false
@@ -50,7 +54,7 @@ func newTestCollector(interval int, redis string) types.Startable {
 }
 
 func TestStartingTheServerWithCLI(t *testing.T) {
-	args := []string{"cli", "-r", "redis-url", "server", "-b", "1.2.3.4", "--max-body-size", "412", "--read-buffer-size", "206"}
+	args := []string{"cli", "-r", "redis-url", "server", "-c", "wildcard_cert", "-k", "wildcard_cert_key", "-b", "1.2.3.4", "--max-body-size", "412", "--read-buffer-size", "206"}
 	subject := CLI{newServer: newTestServer, newCollector: newTestCollector}
 	subject.Start(args)
 
@@ -65,6 +69,18 @@ func TestStartingTheServerWithCLI(t *testing.T) {
 	if expectedRedis != actualRedis {
 		t.Errorf("Expected redis URL to equal %s, got %s", expectedRedis, actualRedis)
 	}
+
+  expectedCert := "wildcard_cert"
+  actualCert := fakeServer.cert
+  if expectedCert != actualCert {
+    t.Errorf("Expected cert to equal %s, got %s", expectedCert, actualCert)
+  }
+
+  expectedKey := "wildcard_cert_key"
+  actualKey := fakeServer.key
+  if expectedKey != actualKey {
+    t.Errorf("Expected key to equal %s, got %s", expectedKey, actualKey)
+  }
 
 	expectedMaxBodySize := 412 * 1024 * 1024
 	actualMaxBodySize := fakeServer.maxBodySize

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -88,6 +88,19 @@ type CertificateTest struct {
 	success     bool
 }
 
+var wildcardCertTest = 	CertificateTest{
+	description: "Wildcard cert default returns successfully",
+	services: []service.Service{
+		{
+			URL:     "http://my-service:3000",
+			DNSName: "example.local",
+			Secure:  true,
+		},
+	},
+	host:    "example.local",
+	success: true,
+}
+
 var certificateTests = []CertificateTest{
 	{
 		description: "Missing services do not return successfully",
@@ -131,11 +144,21 @@ func TestCertificates(t *testing.T) {
 		subject := NewRouter()
 		subject.UpdateTable(test.services)
 
-		_, ok := subject.CertificateForService(test.host)
+		_, ok := subject.CertificateForService(test.host, "", "")
 
 		if ok != test.success {
 			t.Errorf("Test failed: certificate fetching did not match: %s", test.description)
 		}
 
 	}
+
+  // Test for defaulted wildcard cert
+  subject := NewRouter()
+  subject.UpdateTable(wildcardCertTest.services)
+
+  _, ok := subject.CertificateForService(wildcardCertTest.host, string(certificate), string(key))
+
+  if ok != wildcardCertTest.success {
+    t.Errorf("Test failed: default certificate fetching did not match: %s", wildcardCertTest.description)
+  }
 }

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,8 @@ type Server struct {
   readBufferSize int
 	cache       cache.Cache
 	router      *router.Router
+  cert        string
+  key         string
 }
 
 func (s *Server) syncServices() {
@@ -62,7 +64,7 @@ func (s *Server) ServeHTTP(ctx *fasthttp.RequestCtx) {
 }
 
 func (s *Server) getCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cert, ok := s.router.CertificateForService(clientHello.ServerName)
+	cert, ok := s.router.CertificateForService(clientHello.ServerName, s.cert, s.key)
 	if !ok {
 		return cert, errors.New("Failed to lookup certificate")
 	}
@@ -104,8 +106,8 @@ func (s *Server) Start() {
 }
 
 // NewServer returns a new instrance of the server
-func NewServer(bind, redis string, maxBodySize int, readBufferSize int) types.Startable {
+func NewServer(bind, redis, cert, key string, maxBodySize, readBufferSize int) types.Startable {
 	router := router.NewRouter()
 	cache := cache.NewCache(redis)
-	return types.Startable(&Server{bindAddress: bind, maxBodySize: maxBodySize, readBufferSize: readBufferSize, router: router, cache: cache})
+	return types.Startable(&Server{bindAddress: bind, maxBodySize: maxBodySize, readBufferSize: readBufferSize, router: router, cache: cache, cert: cert, key: key})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -30,6 +30,7 @@ func (s *Service) ParseCertificate() bool {
 
 	parsedCert, err := tls.X509KeyPair([]byte(s.EncodedCert), []byte(s.EncodedKey))
 	if err != nil {
+		log.Printf(err.Error())
 		log.Printf("Failed to parse certificate for %s", s.DNSName)
 		return false
 	}


### PR DESCRIPTION
Added the ability for global certificate (as in the case of a wildcard) to apply to all routed services.