### PR TITLE
Some small security improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,10 @@ dev: dev-compile
 	@docker network create --driver=overlay router-management
 	@docker service create --name router-storage --network router-management redis:3.2-alpine
 	@docker service create --name router-backend --constraint node.role==manager --mount \
-		target=/var/run/docker.sock,source=/var/run/docker.sock,type=bind --network router-management \
+		target=/var/run/docker.sock,source=/var/run/docker.sock,type=bind,readonly --network router-management \
 		swarm-ingress-router-dev:latest -r router-storage:6379 collector
 	@docker service create --name router -p 80:8080 -p 443:8443 --network frontends \
-		--network router-management swarm-ingress-router-dev:latest -r \
+		--network router-management --user nobody swarm-ingress-router-dev:latest -r \
 		router-storage:6379 server -b 0.0.0.0
 	@docker service create --name frontend --label ingress=true --label ingress.dnsname=example.local \
 		--label ingress.targetport=80 --network frontends --label ingress.tls=true --label \

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Then you have to start the router's backend on management network. The service m
 run only on master nodes (as it has to query for services).
 
     docker service create --name router-backend --constraint node.role==manager --mount \
-      target=/var/run/docker.sock,source=/var/run/docker.sock,type=bind --network router-management \
+      target=/var/run/docker.sock,source=/var/run/docker.sock,type=bind,readonly --network router-management \
       tpbowden/swarm-ingress-router:latest -r router-storage:6379 collector
 
 Now you can start the router's frontend on both the management and frontend network.
 It must listen on the standard HTTP/HTTPS ports 
 
     docker service create --name router --mode global -p 80:8080 -p 443:8443 --network frontends \
-      --network router-management tpbowden/swarm-ingress-router:latest -r \
+      --network router-management --user nobody tpbowden/swarm-ingress-router:latest -r \
       router-storage:6379 server -b 0.0.0.0
 
 ### Start a demo app


### PR DESCRIPTION
Some small security improvements for the examples namely:
not run forward facing router component as root in the examples, 
and setting the docker socket to readonly mode for the manager.

I would've liked to run the backend as non-root as well, but I didn't want to make too many assumptions about the mounting of that socket.

I figure at least the part that is outward facing should run as a nologin user at the very least.